### PR TITLE
Update connector and proxy packages, readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Create a new lambda function with a publicly available function url. Choose uplo
 
 ### Some notes
 
-This is a demo and only has an http get and post connector currently. It also requires minor changes to be merged upstream to the `spiffworflow-proxy` and `connector-http` packages since Lambda functions require Python 3.9. If this were used outside of a demo it would be nice to be able to opt out of the flask portions of `spiffworkflow-proxy` or extract the `PluginService` to reduce the deployment size.
+This is a demo and only has an http get and post connector currently. If this were used outside of a demo it would be nice to be able to opt out of the flask portions of `spiffworkflow-proxy` or extract the `PluginService` to reduce the deployment size.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ packages = [{include = "connector_proxy_lambda_demo"}]
 
 [tool.poetry.dependencies]
 python = "3.9.*"
-spiffworkflow-proxy = {git = "https://github.com/sartography/spiffworkflow-proxy", rev="lambda_demo"}
-connector-http = {git = "https://github.com/sartography/connector-http.git", rev="lambda_demo"}
+spiffworkflow-proxy = {git = "https://github.com/sartography/spiffworkflow-proxy"}
+connector-http = {git = "https://github.com/sartography/connector-http.git"}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"


### PR DESCRIPTION
Now that the prs to allow Python 3.9 have been merged for those packages.